### PR TITLE
Not all objects have an id field. Use pk instead

### DIFF
--- a/locking/models.py
+++ b/locking/models.py
@@ -27,7 +27,7 @@ def _get_lock_name(obj):
     :returns: a name for this object
     :rtype: :class:`str`
     '''
-    return '%s.%s__%d' % (obj.__module__, obj.__class__.__name__, obj.id)
+    return '%s.%s__%s' % (obj.__module__, obj.__class__.__name__, obj.pk)
 
 
 class LockManager(models.Manager):


### PR DESCRIPTION
In _get_lock_name, the code uses obj.id, but objects can be created without an id field. Using .pk is more general and should give the same result when an id field exists